### PR TITLE
Allow mass recategorization, prevent duplicate transactions

### DIFF
--- a/client/components/TransactionTable.jsx
+++ b/client/components/TransactionTable.jsx
@@ -12,14 +12,15 @@ class TransactionTable extends React.Component {
   handleSelect({ target, nativeEvent }) {
     const { value } = target;
     const id = target.attributes['data-id'].value;
+    const name = nativeEvent.path[2].children[0].innerText;
 
     if (!(+target.attributes['data-tier'].value)) {
       this.dispatch(updateTransaction({ id, categories: `["${value}"]` }));
-      this.dispatch(rerenderTransactions({ id, categories: [value] }));
+      this.dispatch(rerenderTransactions({ id, categories: [value], name }));
     } else {
       const main = nativeEvent.path[2].children[3].children[0].value;
       this.dispatch(updateTransaction({ id, categories: `["${main}","${value}"]` }));
-      this.dispatch(rerenderTransactions({ id, categories: [main, value] }));
+      this.dispatch(rerenderTransactions({ id, categories: [main, value], name }));
     }
   }
 

--- a/client/helpers/transactionHelpers.jsx
+++ b/client/helpers/transactionHelpers.jsx
@@ -96,7 +96,7 @@ const convertTransactions = (transactions) => transactions
   .filter(transaction => !!transaction && transaction.amount)
   .map((transaction) => {
     if (transaction.categories.length < 2) {
-      transaction.categories[1] = 'Uncategorized'
+      transaction.categories[1] = 'Uncategorized';
     }
     transaction.amount = +transaction.amount;
     transaction.date = transaction.date.slice(0, 10);
@@ -106,6 +106,9 @@ const convertTransactions = (transactions) => transactions
 const overwriteTransactionCategories = (transactions, { id, categories, name }) => transactions
   .map((transaction) => {
     if (transaction.id === (+id) || transaction.name === name) {
+      if (categories.length < 2) {
+        categories[1] = 'Uncategorized';
+      }
       transaction.categories = categories;
     }
     return transaction;

--- a/client/helpers/transactionHelpers.jsx
+++ b/client/helpers/transactionHelpers.jsx
@@ -103,9 +103,9 @@ const convertTransactions = (transactions) => transactions
     return transaction;
   });
 
-const overwriteTransactionCategories = (transactions, { id, categories }) => transactions
+const overwriteTransactionCategories = (transactions, { id, categories, name }) => transactions
   .map((transaction) => {
-    if (transaction.id === (+id)) {
+    if (transaction.id === (+id) || transaction.name === name) {
       transaction.categories = categories;
     }
     return transaction;

--- a/client/reducers/transReducer.js
+++ b/client/reducers/transReducer.js
@@ -12,7 +12,6 @@ export default function (state, action) {
     break;
   }
   case 'FETCH_TRANSACTIONS_SUCCESSFUL': {
-    console.log(convertTransactions(action.payload));
     newState.transactionsData = convertTransactions(action.payload);
     break;
   }

--- a/database/database.js
+++ b/database/database.js
@@ -104,6 +104,7 @@ db.schema.createTableIfNotExists('addresses', (addresses) => {
     transactions.foreign('business_id').references('businesses.id');
     transactions.dropForeign('business_id');
     transactions.string('category_id');
+    transactions.string('plaidTransactionId').unique();
     transactions.timestamps();
   });
 }).then((transactions) => {

--- a/database/models/business.js
+++ b/database/models/business.js
@@ -9,4 +9,15 @@ module.exports = db.Model.extend({
   transactions: () => this.hasMany(Transaction),
   category: () => this.belongsTo(Category),
   address: () => this.belongsTo(Address),
+  initialize() {
+    this.on('created', ({ attributes }) => {
+      const Business = require('./business');
+      const { name, id } = attributes;
+      Business.where({ name }).fetch()
+      .then(existingBusiness => existingBusiness.attributes.category_id)
+      .then(category_id => Business.forge({ id }).save({ category_id }));
+    }).catch((err) => {
+      console.log(err);
+    });
+  },
 });

--- a/database/models/business.js
+++ b/database/models/business.js
@@ -15,9 +15,10 @@ module.exports = db.Model.extend({
       const { name, id } = attributes;
       Business.where({ name }).fetch()
       .then(existingBusiness => existingBusiness.attributes.category_id)
-      .then(category_id => Business.forge({ id }).save({ category_id }));
-    }).catch((err) => {
-      console.log(err);
+      .then(category_id => Business.forge({ id }).save({ category_id }))
+      .catch((err) => {
+        console.log(err);
+      });
     });
   },
 });

--- a/database/models/transaction.js
+++ b/database/models/transaction.js
@@ -11,4 +11,15 @@ module.exports = db.Model.extend({
   account: () => this.belongsTo(Account),
   business: () => this.belongsTo(Business),
   categories: () => this.belongsTo(Category),
+  initialize() {
+    this.on('created', ({ attributes }) => {
+      const Transaction = require('./transaction');
+      const { business_id, id } = attributes;
+      Business.where({ id: business_id }).fetch()
+      .then(business => business.attributes.category_id)
+      .then(category_id => Transaction.forge({ id }).save({ category_id }));
+    }).catch((err) => {
+      console.log(err);
+    });
+  },
 });

--- a/database/models/transaction.js
+++ b/database/models/transaction.js
@@ -17,9 +17,10 @@ module.exports = db.Model.extend({
       const { business_id, id } = attributes;
       Business.where({ id: business_id }).fetch()
       .then(business => business.attributes.category_id)
-      .then(category_id => Transaction.forge({ id }).save({ category_id }));
-    }).catch((err) => {
-      console.log(err);
+      .then(category_id => Transaction.forge({ id }).save({ category_id }))
+      .catch((err) => {
+        console.log(err);
+      });
     });
   },
 });

--- a/server/controllers/transactions.js
+++ b/server/controllers/transactions.js
@@ -24,6 +24,7 @@ module.exports = {
     .then(transactions => Promise.all(transactions.map((transaction) => {
       delete transaction.attributes.created_at;
       delete transaction.attributes.updated_at;
+      delete transaction.attributes.plaidTransactionId;
       return transaction;
     })))
     .then((transactions) => {
@@ -66,6 +67,7 @@ module.exports = {
         account_id: account.id,
         business_id: businessId,
         category_id: category.id,
+        plaidTransactionId: transaction._id,
         amount: transaction.amount,
         date: transaction.date,
       };


### PR DESCRIPTION
- Recategorizing single transaction triggers mass recategorization of businesses and identical transactions
- Transactions no longer duplicate
- New transactions and businesses pull categories from preexisting ones